### PR TITLE
migrated from manifest splash screen for flutter-2.5.3

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,10 +23,6 @@
                  screen fades out. A splash screen is useful to avoid any visual
                  gap between the end of Android's launch screen and the painting of
                  Flutter's first frame. -->
-            <meta-data
-              android:name="io.flutter.embedding.android.SplashScreenDrawable"
-              android:resource="@drawable/launch_background"
-              />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
### Description of the PR:
Removed the Android Manifest Splash Screen.

### Reason:
Manifest splash screens are deprecated starting from Flutter 2.5.3
You can find more info on this [here](https://flutter.dev/docs/development/ui/advanced/splash-screen#migrating-from-manifest--activity-defined-custom-splash-screens).

### Actual warning log:
```
A splash screen was provided to Flutter, but this is deprecated.
See flutter.dev/go/android-splash-migration for migration steps.
```